### PR TITLE
PLAT-4057: eliminate collections as default parameters

### DIFF
--- a/socotratools/socotratools/client.py
+++ b/socotratools/socotratools/client.py
@@ -133,8 +133,10 @@ class SocotraClient:
             'hostName': host_name
         }
         return_value = self.__post('/account/authenticate', data)
-        self.session.headers.update(
-            {"Authorization": return_value['authorizationToken']})
+        self.session.headers.update({
+            "Authorization": return_value['authorizationToken'],
+            "Socotra-Forced-Flags": "property.endorsement.renewal.underwriting.enabled=true"
+        })
         return return_value
 
     def renew(self):
@@ -460,48 +462,57 @@ class SocotraClient:
             return 'created'
 
     def create_endorsement(self, policy_locator, endorsement_name,
-                           effective_timestamp, end_timestamp=None,
-                           field_values={}, add_field_groups=[],
-                           update_field_groups=[], remove_field_groups=[],
-                           add_exposures=[], update_exposures=[],
-                           end_exposures=[], action=None):
-
+                           effective_timestamp=None,
+                           field_values=None,
+                           add_field_groups=None,
+                           remove_field_groups=None,
+                           update_field_groups=None,
+                           add_exposures=None,
+                           end_exposures=None,
+                           update_exposures=None,
+                           end_timestamp=None,
+                           # above: optional
+                           state='application'):
         data = {'endorsementName': endorsement_name,
                 'startTimestamp': effective_timestamp,
-                'newPolicyEndTimestamp': end_timestamp,
                 'fieldValues': field_values,
                 'addFieldGroups': add_field_groups,
-                'updateFieldGroups': update_field_groups,
                 'removeFieldGroups': remove_field_groups,
+                'updateFieldGroups': update_field_groups,
                 'addExposures': add_exposures,
-                'updateExposures': update_exposures,
                 'endExposures': end_exposures,
-                'action': action
-                }
-
+                'updateExposures': update_exposures,
+                'newPolicyEndTimestamp': end_timestamp,
+                'state': state}
         return self.__post("/policies/" + policy_locator +
                            "/endorsements", data)
 
     def update_endorsement(self, endorsement_locator,
-                           effective_timestamp=None, end_timestamp=None,
-                           field_values={}, add_field_groups=[],
-                           update_field_groups=[], remove_field_groups=[],
-                           add_exposures=[], update_exposures=[],
-                           end_exposures=[], action=None):
-
-        update = {'fieldValues': field_values,
-                  'addFieldGroups': add_field_groups,
-                  'updateFieldGroups': update_field_groups,
-                  'removeFieldGroups': remove_field_groups,
-                  'addExposures': add_exposures,
-                  'updateExposures': update_exposures,
-                  'endExposures': end_exposures
-                  }
-
-        data = {'endorsementUpdate': {},
-                'action': action
-                }
-
+                           effective_timestamp=None,
+                           field_values=None,
+                           add_field_groups=None,
+                           remove_field_groups=None,
+                           update_field_groups=None,
+                           add_exposures=None,
+                           end_exposures=None,
+                           update_exposures=None,
+                           end_timestamp=None,
+                           # above: optional
+                           action='update'):
+        affects_exposures = add_exposures or end_exposures or update_exposures  # alias end/remove_exposures?
+        affects_fields = field_values or add_field_groups or remove_field_groups or update_field_groups
+        endorsement_update = None if not (end_timestamp or affects_exposures or affects_fields) else {
+            'startTimestamp': effective_timestamp,
+            'fieldValues': field_values,
+            'addFieldGroups': add_field_groups,
+            'removeFieldGroups': remove_field_groups,
+            'updateFieldGroups': update_field_groups,
+            'addExposures': add_exposures,
+            'endExposures': end_exposures,
+            'updateExposures': update_exposures,
+            'newPolicyEndTimestamp': end_timestamp,
+        }
+        data = {'action': action, 'endorsementUpdate': endorsement_update}
         return self.__patch("/endorsements/" + endorsement_locator, data)
 
     def get_endorsement(self, endorsement_locator):
@@ -522,13 +533,18 @@ class SocotraClient:
         return self.__get("/policies/" + policy_locator +
                           "/endorsements")
 
-    def create_renewal(self, policy_locator, end_timestamp=None,
-                       field_values={}, add_field_groups=[],
-                       update_field_groups=[], remove_field_groups=[],
-                       add_exposures=[], update_exposures=[],
-                       end_exposures=[], action=None):
-
-        data = {'renewalEndTimestamp': end_timestamp,
+    def create_renewal(self, policy_locator,
+                       field_values=None,
+                       add_field_groups=None,
+                       remove_field_groups=None,
+                       update_field_groups=None,
+                       add_exposures=None,
+                       end_exposures=None,
+                       update_exposures=None,
+                       # above: optional
+                       end_timestamp=None,
+                       state='application'):
+        data = {
                 'fieldValues': field_values,
                 'addFieldGroups': add_field_groups,
                 'updateFieldGroups': update_field_groups,
@@ -536,33 +552,35 @@ class SocotraClient:
                 'addExposures': add_exposures,
                 'updateExposures': update_exposures,
                 'endExposures': end_exposures,
-                'action': action
-                }
-
+                'renewalEndTimestamp': end_timestamp,
+                'state': state}
         return self.__post("/policies/" + policy_locator +
                            "/renewals", data)
 
     def update_renewal(self, renewal_locator,
-                       effective_timestamp=None, end_timestamp=None,
-                       field_values={}, add_field_groups=[],
-                       update_field_groups=[], remove_field_groups=[],
-                       add_exposures=[], update_exposures=[],
-                       end_exposures=[], action=None):
-
-        update = {'renewalEndTimestamp': end_timestamp,
-                  'fieldValues': field_values,
-                  'addFieldGroups': add_field_groups,
-                  'updateFieldGroups': update_field_groups,
-                  'removeFieldGroups': remove_field_groups,
-                  'addExposures': add_exposures,
-                  'updateExposures': update_exposures,
-                  'endExposures': end_exposures
-                  }
-
-        data = {'renewalUpdate': update,
-                'action': action
-                }
-
+                       field_values=None,
+                       add_field_groups=None,
+                       remove_field_groups=None,
+                       update_field_groups=None,
+                       add_exposures=None,
+                       end_exposures=None,
+                       update_exposures=None,
+                       end_timestamp=None,
+                       # above: optional
+                       action='update'):
+        affects_exposures = add_exposures or end_exposures or update_exposures  # alias end/remove_exposures?
+        affects_fields = field_values or add_field_groups or remove_field_groups or update_field_groups
+        renewal_update = None if not (end_timestamp or affects_exposures or affects_fields) else {
+            'fieldValues': field_values,
+            'addFieldGroups': add_field_groups,
+            'updateFieldGroups': update_field_groups,
+            'removeFieldGroups': remove_field_groups,
+            'addExposures': add_exposures,
+            'updateExposures': update_exposures,
+            'endExposures': end_exposures,
+            'renewalEndTimestamp': end_timestamp,
+        }
+        data = {'action': action, 'renewalUpdate': renewal_update}
         return self.__patch("/renewals/" + renewal_locator, data)
 
     def get_renewal(self, renewal_locator):


### PR DESCRIPTION
Defaulting keyword parameters like `=[]` and `={}` should be `=None`.

In the body of the function, check for `None` and set to default. (as needed)

https://docs.python-guide.org/writing/gotchas/

This **suggested** fix also addresses some expected usage paper cuts.

At PDM discretion, it may merged to the branch as-is or patched ad hoc.